### PR TITLE
fix issue 24

### DIFF
--- a/algorithms/detection/pattern_continuity.py
+++ b/algorithms/detection/pattern_continuity.py
@@ -167,13 +167,11 @@ def detect_pattern_continuity(
 
         return score, details
 
-    except (PatternDetectionError, ImageDimensionError, ContinuityAnalysisError):
-        # 重新抛出我们的自定义异常
-        raise
     except Exception as e:
-        # 捕获其他异常并转换为PatternDetectionError
-        logger.error(f"图案连续性检测时发生未知错误: {str(e)}")
-        raise PatternDetectionError(f"未知错误: {str(e)}")
+        err_msg = str(e)
+        error_type = type(e).__name__
+        logger.error(f"图案连续性检测失败：{err_msg}")
+        return None, {'err_msg': err_msg, 'error_type': error_type}
 
 
 def get_adaptive_threshold(image: np.ndarray, config: PatternContinuityConfig) -> int:

--- a/plans/issues/issue_24.md
+++ b/plans/issues/issue_24.md
@@ -1,0 +1,222 @@
+# Issue #24: BUG:tmp 兼容性&异常处理
+
+**Issue URL**: https://github.com/ydhh-test/giti-tire-ai-pattern/issues/24
+
+**创建日期**: 2026-03-12
+
+---
+
+## Bug 描述
+
+### Bug 1: `/tmp` 目录兼容性问题
+
+Windows 不支持 `/tmp` 目录，需要改为 `.results/tmp`。
+
+**涉及文件**:
+- `tests/unittests/services/test_postprocessor.py`
+
+**说明**: 经检查，`test_postprocessor_pipeline.py` 和 `test_cv_utils.py` 使用的是 pytest 的 `tmp_path` fixture（跨平台兼容），无需修改。只有 `test_postprocessor.py` 中的 `TestLoadUserConf` 和 `TestStageFunctions` 测试类使用了硬编码的 `Path("/tmp/...")`。
+
+### Bug 2: `pattern_continuity.py` 异常处理逻辑不对
+
+当前异常处理使用 `raise`，需要改为返回 `None` 和错误信息字典。
+
+**涉及文件**:
+- `algorithms/detection/pattern_continuity.py`（主函数异常处理）
+- `rules/rule6_1.py`（调用方检查返回值）
+
+---
+
+## 修复计划
+
+### Bug 1: `/tmp` 目录兼容性
+
+#### 修改 1: `TestLoadUserConf` 测试类迁移
+
+**位置**: `tests/unittests/services/test_postprocessor.py` 第 95-144 行
+
+**修改前**:
+```python
+class TestLoadUserConf(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path("/tmp/test_postprocessor")
+        self.test_dir.mkdir(exist_ok=True)
+
+    def tearDown(self):
+        if self.test_dir.exists():
+            shutil.rmtree(self.test_dir)
+```
+
+**修改后**:
+```python
+class TestLoadUserConf:
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        self.test_dir = tmp_path / "test_postprocessor"
+        # pytest 自动清理，无需 tearDown
+```
+
+#### 修改 2: `TestStageFunctions` 测试类迁移
+
+**位置**: `tests/unittests/services/test_postprocessor.py` 第 179-218 行
+
+**修改前**:
+```python
+class TestStageFunctions(unittest.TestCase):
+    def setUp(self):
+        self.task_id = "test_task"
+        self.test_dir = Path("/tmp/test_postprocessor_stages")
+        self.test_dir.mkdir(exist_ok=True)
+
+    def tearDown(self):
+        if self.test_dir.exists():
+            shutil.rmtree(self.test_dir)
+```
+
+**修改后**:
+```python
+class TestStageFunctions:
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        self.task_id = "test_task"
+        self.test_dir = tmp_path / "test_postprocessor_stages"
+        # pytest 自动清理，无需 tearDown
+```
+
+#### 修改 3: 新增正例测试类
+
+**位置**: `tests/unittests/services/test_postprocessor.py`
+
+**目的**: 留下实际输出供检查，测试后不清理
+
+**新增内容**:
+```python
+class TestPositiveExample:
+    """正例测试 - 输出保留供检查"""
+
+    @pytest.mark.trylast
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """设置固定输出目录，测试后不清理"""
+        self.output_dir = Path(".results/tmp/positive_example")
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        yield
+        # 不清理输出，供人工检查
+
+    def test_positive_example(self):
+        """正例测试 - 验证基本功能并保留输出"""
+        # 测试逻辑，输出到 self.output_dir
+        pass
+```
+
+---
+
+### Bug 2: `pattern_continuity.py` 异常处理
+
+#### 修改 1: 主函数异常处理
+
+**位置**: `algorithms/detection/pattern_continuity.py` 第 170-176 行
+
+**修改前**:
+```python
+except (PatternDetectionError, ImageDimensionError, ContinuityAnalysisError):
+    # 重新抛出我们的自定义异常
+    raise
+except Exception as e:
+    # 捕获其他异常并转换为 PatternDetectionError
+    logger.error(f"图案连续性检测时发生未知错误：{str(e)}")
+    raise PatternDetectionError(f"未知错误：{str(e)}")
+```
+
+**修改后**:
+```python
+except Exception as e:
+    err_msg = str(e)
+    error_type = type(e).__name__
+    logger.error(f"图案连续性检测失败：{err_msg}")
+    return None, {'err_msg': err_msg, 'error_type': error_type}
+```
+
+#### 修改 2: 调用方检查返回值
+
+**位置**: `rules/rule6_1.py` `process_pattern_continuity_single_dir()` 函数中（第 160-168 行附近）
+
+**修改前**:
+```python
+score, details = detect_pattern_continuity(
+    image=gray,
+    conf=pattern_continuity_conf,
+    task_id=task_id,
+    image_type=filter_dir,
+    image_id=str(image_id),
+    visualize=visualize,
+    output_base_dir=str(vis_output_dir)
+)
+
+# 判断连续性
+is_continuous = details.get('is_continuous', False)
+```
+
+**修改后**:
+```python
+score, details = detect_pattern_continuity(
+    image=gray,
+    conf=pattern_continuity_conf,
+    task_id=task_id,
+    image_type=filter_dir,
+    image_id=str(image_id),
+    visualize=visualize,
+    output_base_dir=str(vis_output_dir)
+)
+
+# 检查是否返回错误
+if score is None:
+    err_msg = details.get('err_msg', '未知错误')
+    error_type = details.get('error_type', 'UnknownError')
+    logger.error(f"图案连续性检测失败，图片路径：{image_path}, "
+                 f"错误类型：{error_type}, 错误信息：{err_msg}")
+    stats["images"][image_path.name] = {
+        "error": err_msg,
+        "error_type": error_type,
+        "deleted": True
+    }
+    stats["deleted_count"] += 1
+    continue
+
+# 判断连续性
+is_continuous = details.get('is_continuous', False)
+```
+
+---
+
+## 修改文件清单
+
+| 文件 | 修改内容 |
+|------|---------|
+| `tests/unittests/services/test_postprocessor.py` | 1. `TestLoadUserConf` 迁移到 pytest 风格 |
+| | 2. `TestStageFunctions` 迁移到 pytest 风格 |
+| | 3. 新增 `TestPositiveExample` 测试类 |
+| `algorithms/detection/pattern_continuity.py` | 主函数异常处理改为返回 `None, {err_msg, error_type}` |
+| `rules/rule6_1.py` | 调用方检查 `score is None`，记录错误后 `continue` |
+
+---
+
+## 注意事项
+
+1. **Bug 1 修改范围**: 只修改 `test_postprocessor.py`，另外两个测试文件使用的是 pytest 的 `tmp_path` fixture，无需修改。
+
+2. **正例测试原则**: 正例测试类使用 `@pytest.mark.trylast` 确保最后执行，输出到 `.results/tmp/positive_example` 目录，测试后不清理，供人工检查。
+
+3. **Bug 2 异常返回格式**: 返回 `None, {'err_msg': str(e), 'error_type': type(e).__name__}`。
+
+4. **Bug 2 调用方处理**: 检测到 `score is None` 时，记录错误图片路径、错误类型、错误信息，然后 `continue` 处理下一张图片。
+
+---
+
+## 实施步骤
+
+1. [ ] 修改 `test_postprocessor.py` - `TestLoadUserConf` 迁移到 pytest 风格
+2. [ ] 修改 `test_postprocessor.py` - `TestStageFunctions` 迁移到 pytest 风格
+3. [ ] 修改 `test_postprocessor.py` - 新增 `TestPositiveExample` 测试类
+4. [ ] 修改 `pattern_continuity.py` - 主函数异常处理
+5. [ ] 修改 `rule6_1.py` - 调用方检查返回值

--- a/rules/rule6_1.py
+++ b/rules/rule6_1.py
@@ -168,6 +168,20 @@ def process_pattern_continuity_single_dir(
             )
 
             # 判断连续性
+            # 检查是否返回错误
+            if score is None:
+                err_msg = details.get('err_msg', '未知错误')
+                error_type = details.get('error_type', 'UnknownError')
+                logger.error(f"图案连续性检测失败，图片路径：{image_path}, "
+                             f"错误类型：{error_type}, 错误信息：{err_msg}")
+                stats["images"][image_path.name] = {
+                    "error": err_msg,
+                    "error_type": error_type,
+                    "deleted": True
+                }
+                stats["deleted_count"] += 1
+                continue
+
             is_continuous = details.get('is_continuous', False)
 
             # 记录结果

--- a/tests/unittests/services/test_postprocessor.py
+++ b/tests/unittests/services/test_postprocessor.py
@@ -18,6 +18,7 @@ import json
 import shutil
 from pathlib import Path
 from unittest.mock import patch, MagicMock
+import pytest
 
 # 添加项目根目录到 Python 路径
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
@@ -92,24 +93,21 @@ def cleanup_task_data(task_id: str):
         shutil.rmtree(task_dir)
 
 
-class TestLoadUserConf(unittest.TestCase):
+class TestLoadUserConf:
     """测试 _load_user_conf 函数"""
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
         """设置测试环境"""
-        self.test_dir = Path("/tmp/test_postprocessor")
+        self.test_dir = tmp_path / "test_postprocessor"
         self.test_dir.mkdir(exist_ok=True)
-
-    def tearDown(self):
-        """清理测试环境"""
-        if self.test_dir.exists():
-            shutil.rmtree(self.test_dir)
+        # pytest 自动清理，无需 tearDown
 
     def test_user_conf_dict_input(self):
         """测试 dict 类型输入"""
         user_conf = {"key1": "value1", "key2": 123}
         result = _load_user_conf(user_conf)
-        self.assertEqual(result, user_conf)
+        assert result == user_conf
 
     def test_user_conf_json_path_input(self):
         """测试 JSON 文件路径输入"""
@@ -119,13 +117,12 @@ class TestLoadUserConf(unittest.TestCase):
             json.dump(test_conf, f)
 
         result = _load_user_conf(str(json_path))
-        self.assertEqual(result, test_conf)
+        assert result == test_conf
 
     def test_user_conf_invalid_type(self):
         """测试无效类型输入（应报错）"""
-        with self.assertRaises(TypeError) as context:
+        with pytest.raises(TypeError, match="user_conf must be dict or str"):
             _load_user_conf(12345)
-        self.assertIn("user_conf must be dict or str", str(context.exception))
 
     def test_user_conf_invalid_json(self):
         """测试无效 JSON 文件（应报错）"""
@@ -133,14 +130,13 @@ class TestLoadUserConf(unittest.TestCase):
         with open(json_path, 'w', encoding='utf-8') as f:
             f.write("{invalid json content")
 
-        with self.assertRaises(json.JSONDecodeError):
+        with pytest.raises(json.JSONDecodeError):
             _load_user_conf(str(json_path))
 
     def test_user_conf_file_not_found(self):
         """测试 JSON 文件不存在（应报错）"""
-        with self.assertRaises(FileNotFoundError) as context:
+        with pytest.raises(FileNotFoundError, match="JSON config file not found"):
             _load_user_conf("/non/existent/path/config.json")
-        self.assertIn("JSON config file not found", str(context.exception))
 
 
 class TestMergeConfFromCompleteConfig(unittest.TestCase):
@@ -176,45 +172,41 @@ class TestCreateErrorResponse(unittest.TestCase):
         self.assertEqual(details["task_id"], task_id)
 
 
-class TestStageFunctions(unittest.TestCase):
+class TestStageFunctions:
     """测试各阶段内部函数"""
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
         """设置测试环境"""
         self.task_id = "test_task"
-        self.test_dir = Path("/tmp/test_postprocessor_stages")
-        self.test_dir.mkdir(exist_ok=True)
-
-    def tearDown(self):
-        """清理测试环境"""
-        if self.test_dir.exists():
-            shutil.rmtree(self.test_dir)
+        self.test_dir = tmp_path / "test_postprocessor_stages"
+        # pytest 自动清理，无需 tearDown
 
     def test_small_image_filter_empty(self):
         """测试小图筛选空函数"""
         flag, details = _small_image_filter(self.task_id, {})
-        self.assertTrue(flag)
-        self.assertIn("image_gen_number", details)
-        self.assertEqual(details["task_id"], self.task_id)
+        assert flag is True
+        assert "image_gen_number" in details
+        assert details["task_id"] == self.task_id
 
     def test_small_image_score_empty(self):
         """测试小图打分空函数"""
         flag, details = _small_image_score(self.task_id, {})
-        self.assertTrue(flag)
-        self.assertIn("image_gen_number", details)
+        assert flag is True
+        assert "image_gen_number" in details
 
     def test_horizontal_image_score_empty(self):
         """测试横图打分空函数"""
         flag, details = _horizontal_image_score(self.task_id, {})
-        self.assertTrue(flag)
-        self.assertIn("image_gen_number", details)
+        assert flag is True
+        assert "image_gen_number" in details
 
     def test_standard_input_empty(self):
         """测试整理输出空函数"""
         input_details = {"image_gen_number": 5, "test_key": "test_value"}
         flag, details = _standard_input(self.task_id, {}, input_details)
-        self.assertTrue(flag)
-        self.assertEqual(details, input_details)
+        assert flag is True
+        assert details == input_details
 
 
 class TestAddDecorationBorders(unittest.TestCase):
@@ -430,6 +422,28 @@ class TestPostprocessorIntegration(unittest.TestCase):
         self.assertIn("failed_stage", details)
         self.assertEqual(details["failed_stage"], "vertical_stitch")
         self.assertIn("err_msg", details)
+
+
+
+class TestPositiveExample:
+    """正例测试 - 输出保留供检查"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """设置固定输出目录，测试后不清理"""
+        self.output_dir = Path(".results/tmp/positive_example")
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        yield
+        # 不清理输出，供人工检查
+
+    @pytest.mark.trylast
+    def test_positive_example(self):
+        """正例测试 - 验证基本功能并保留输出"""
+        # 测试逻辑，输出到 self.output_dir
+        # 创建一个测试文件证明输出已保留
+        test_output_file = self.output_dir / "test_output.txt"
+        test_output_file.write_text("positive example output", encoding='utf-8')
+        assert test_output_file.exists()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
根据 commit 变更内容，为您生成 Pull Request 文档：

---

## 📋 PR 类型
- [ ] 功能新增
- [ ] 添加测试
- [x] Bug 修复
- [ ] 紧急修复
- [ ] 其他（不影响功能）

## 📝 变更概述
修复 Issue #24 中的两个 Bug：
1. **`/tmp` 目录兼容性问题**：将测试代码中硬编码的 `/tmp` 目录改为使用 pytest 的 `tmp_path` fixture，解决 Windows 系统不支持 `/tmp` 目录的问题
2. **`pattern_continuity.py` 异常处理逻辑**：将异常抛出改为返回 `None` 和错误信息字典，调用方增加错误检测和日志记录

## 🔍 代码审查清单
- [x] 代码风格符合 PEP 规范
- [x] 包含完整的文件注释头（公司信息、作者、AI 助手）
- [x] 代码已格式化
- [x] 无已知 Bug
- [x] 添加了必要的注释

## ✅ 测试状态
- [x] 单元测试通过（20/20 passed）
- [ ] 功能测试通过
- [ ] 回归测试通过

## 📁 变更文件
- 新增文件：
  - `plans/issues/issue_24.md`
- 修改文件：
  - `algorithms/detection/pattern_continuity.py` - 异常处理逻辑修改
  - `rules/rule6_1.py` - 调用方增加返回值检查
  - `tests/unittests/services/test_postprocessor.py` - 测试类迁移到 pytest 风格
- 删除文件：

## 🔗 相关链接
- 相关 Issue: #24
- 相关文档：`plans/issues/issue_24.md`

## 🚀 部署说明
无需特殊部署步骤

## pytest 结果截图（改了代码才需要）
```
pytest tests -vv
========================================================================= test session starts ==========================================================================
platform darwin -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0 -- /opt/miniconda3/envs/py12_giti_speckit/bin/python3.12
cachedir: .pytest_cache
rootdir: /Users/guiyu/aiProjects/claudeProjects/giti-tire-ai-pattern
plugins: anyio-4.12.1
collected 129 items                                                                                                                                                    

tests/integration/services/test_postprocessor_pipeline.py::TestFullPipelineIntegration::test_full_pipeline_with_mock_todos PASSED                                [  0%]
tests/integration/services/test_postprocessor_pipeline.py::TestFullPipelineIntegration::test_full_pipeline_empty_config PASSED                                   [  1%]
tests/integration/services/test_postprocessor_pipeline.py::TestFullPipelineEdgeCases::test_pipeline_with_json_config PASSED                                      [  2%]
tests/integration/services/test_postprocessor_stages.py::TestStage12Integration::test_conf_processing_with_dict PASSED                                           [  3%]
tests/integration/services/test_postprocessor_stages.py::TestStage12Integration::test_small_image_filter_integration PASSED                                      [  3%]
tests/integration/services/test_postprocessor_stages.py::TestStage4Integration::test_vertical_stitch_integration PASSED                                          [  4%]
tests/integration/services/test_postprocessor_stages.py::TestStage5Integration::test_horizontal_stitch_integration PASSED                                        [  5%]
tests/integration/services/test_postprocessor_stages.py::TestStage67Integration::test_horizontal_image_score_integration PASSED                                  [  6%]
tests/integration/services/test_postprocessor_stages.py::TestStage67Integration::test_add_decoration_borders_integration PASSED                                  [  6%]
tests/integration/services/test_postprocessor_stages.py::TestExceptionScenarios::test_invalid_user_conf_type PASSED                                              [  7%]
tests/integration/services/test_postprocessor_stages.py::TestExceptionScenarios::test_json_file_not_found PASSED                                                 [  8%]
tests/integration/services/test_postprocessor_stages.py::TestExceptionScenarios::test_vertical_stitch_empty_config PASSED                                        [  9%]
tests/integration/services/test_postprocessor_stages.py::TestExceptionScenarios::test_horizontal_stitch_empty_config PASSED                                      [ 10%]
tests/integration/services/test_postprocessor_stages.py::TestExceptionScenarios::test_stage_failure_propagation PASSED                                           [ 10%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_can_match_coarse_coarse_fail PASSED                           [ 11%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_can_match_coarse_coarse_success PASSED                        [ 12%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_can_match_coarse_fine_success PASSED                          [ 13%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_can_match_fine_coarse_success PASSED                          [ 13%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_can_match_fine_fine_fail PASSED                               [ 14%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_can_match_fine_fine_success PASSED                            [ 15%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_extract_ends_coarse_lines PASSED                              [ 16%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_extract_ends_filter_noise PASSED                              [ 17%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_extract_ends_fine_lines PASSED                                [ 17%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_extract_ends_mixed_lines PASSED                               [ 18%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_match_ends_count_mismatch PASSED                              [ 19%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_match_ends_empty_edges PASSED                                 [ 20%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_match_ends_large_offset PASSED                                [ 20%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_match_ends_one_to_many PASSED                                 [ 21%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_match_ends_perfect_match PASSED                               [ 22%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuitySimple::test_match_ends_single_side_empty PASSED                           [ 23%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuity::test_continuous_pattern PASSED                                           [ 24%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuity::test_discontinuous_pattern PASSED                                        [ 24%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuity::test_empty_edges PASSED                                                  [ 25%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuity::test_method_comparison PASSED                                            [ 26%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuity::test_one_to_many_matching PASSED                                         [ 27%]
tests/unittests/algorithms/detection/test_pattern_continuity.py::TestPatternContinuity::test_visualization PASSED                                                [ 27%]
tests/unittests/algorithms/stitching/test_horizontal_stitch.py::test_layout_result PASSED                                                                        [ 28%]
tests/unittests/algorithms/stitching/test_horizontal_stitch.py::test_combination_manager_5_rib PASSED                                                            [ 29%]
tests/unittests/algorithms/stitching/test_horizontal_stitch.py::test_combination_manager_4_rib PASSED                                                            [ 30%]
tests/unittests/algorithms/stitching/test_horizontal_stitch.py::test_horizontal_stitch_init PASSED                                                               [ 31%]
tests/unittests/algorithms/stitching/test_horizontal_stitch.py::test_horizontal_stitch_process_with_real_data PASSED                                             [ 31%]
tests/unittests/algorithms/stitching/test_horizontal_stitch.py::test_horizontal_stitch_different_symmetry_types PASSED                                           [ 32%]
tests/unittests/algorithms/stitching/test_vertical_stitch.py::TestStitchAndResize::test_stitch_and_resize_basic PASSED                                           [ 33%]
tests/unittests/algorithms/stitching/test_vertical_stitch.py::TestStitchAndResize::test_stitch_and_resize_single_stitch PASSED                                   [ 34%]
tests/unittests/algorithms/stitching/test_vertical_stitch.py::TestStitchAndResize::test_stitch_and_resize_multi_stitch PASSED                                    [ 34%]
tests/unittests/algorithms/stitching/test_vertical_stitch.py::TestStitchAndResize::test_stitch_and_resize_with_pattern PASSED                                    [ 35%]
tests/unittests/algorithms/stitching/test_vertical_stitch.py::TestStitchAndResize::test_stitch_and_resize_invalid_stitch_zero PASSED                             [ 36%]
tests/unittests/algorithms/stitching/test_vertical_stitch.py::TestStitchAndResize::test_stitch_and_resize_invalid_stitch_negative PASSED                         [ 37%]
tests/unittests/algorithms/stitching/test_vertical_stitch.py::TestStitchAndResize::test_stitch_and_resize_invalid_target_size_single PASSED                      [ 37%]
tests/unittests/algorithms/stitching/test_vertical_stitch.py::TestStitchAndResize::test_stitch_and_resize_invalid_target_size_triple PASSED                      [ 38%]
tests/unittests/algorithms/stitching/test_vertical_stitch.py::TestStitchAndResize::test_stitch_and_resize_invalid_target_size_string PASSED                      [ 39%]
tests/unittests/rules/scoring/test_land_sea_ratio.py::test_compute_black_area PASSED                                                                             [ 40%]
tests/unittests/rules/scoring/test_land_sea_ratio.py::test_compute_gray_area PASSED                                                                              [ 41%]
tests/unittests/rules/scoring/test_land_sea_ratio.py::test_compute_land_sea_ratio_excellent PASSED                                                               [ 41%]
tests/unittests/rules/scoring/test_land_sea_ratio.py::test_compute_land_sea_ratio_pass PASSED                                                                    [ 42%]
tests/unittests/rules/scoring/test_land_sea_ratio.py::test_compute_land_sea_ratio_fail PASSED                                                                    [ 43%]
tests/unittests/rules/scoring/test_land_sea_ratio.py::test_compute_land_sea_ratio_with_actual_image SKIPPED (Test image not found:
tests/datasets/horizontal_stitch/center/0.png)                                                                                                                   [ 44%]
tests/unittests/rules/test_rule13.py::TestRule13::test_get_image_files PASSED                                                                                    [ 44%]
tests/unittests/rules/test_rule13.py::TestRule13::test_aggregate_summary PASSED                                                                                  [ 45%]
tests/unittests/rules/test_rule13.py::TestRule13::test_visualize_score PASSED                                                                                    [ 46%]
tests/unittests/rules/test_rule13.py::TestRule13::test_save_score_json PASSED                                                                                    [ 47%]
tests/unittests/rules/test_rule13.py::TestRule13::test_process_horizontal_image_score_nonexistent_dir PASSED                                                     [ 48%]
tests/unittests/rules/test_rule13.py::TestRule13::test_process_horizontal_image_score_empty_dir PASSED                                                           [ 48%]
tests/unittests/rules/test_rule13.py::TestRule13::test_process_single_image PASSED                                                                               [ 49%]
tests/unittests/rules/test_rule13.py::TestRule13::test_process_horizontal_image_score_full PASSED                                                                [ 50%]
tests/unittests/rules/test_rule19.py::TestRule19::test_get_image_files PASSED                                                                                    [ 51%]
tests/unittests/rules/test_rule19.py::TestRule19::test_aggregate_summary PASSED                                                                                  [ 51%]
tests/unittests/rules/test_rule19.py::TestRule19::test_build_empty_result PASSED                                                                                 [ 52%]
tests/unittests/rules/test_rule19.py::TestRule19::test_process_decoration_borders_nonexistent_dir PASSED                                                         [ 53%]
tests/unittests/rules/test_rule19.py::TestRule19::test_process_decoration_borders_empty_dir PASSED                                                               [ 54%]
tests/unittests/rules/test_rule19.py::TestRule19::test_process_single_image PASSED                                                                               [ 55%]
tests/unittests/rules/test_rule19.py::TestRule19::test_process_decoration_borders_full PASSED                                                                    [ 55%]
tests/unittests/rules/test_rule1to5.py::TestRule1to5::test_process_horizontal_stitch_success PASSED                                                              [ 56%]
tests/unittests/rules/test_rule6_1.py::TestRule6_1::test_get_image_files PASSED                                                                                  [ 57%]
tests/unittests/rules/test_rule6_1.py::TestRule6_1::test_copy_images PASSED                                                                                      [ 58%]
tests/unittests/rules/test_rule6_1.py::TestRule6_1::test_aggregate_summary PASSED                                                                                [ 58%]
tests/unittests/rules/test_rule6_1.py::TestRule6_1::test_build_vis_output_dir PASSED                                                                             [ 59%]
tests/unittests/rules/test_rule6_1.py::TestRule6_1::test_process_pattern_continuity_single_dir_center PASSED                                                     [ 60%]
tests/unittests/rules/test_rule6_1.py::TestRule6_1::test_process_pattern_continuity_single_dir_side PASSED                                                       [ 61%]
tests/unittests/rules/test_rule6_1.py::TestRule6_1::test_process_pattern_continuity_full PASSED                                                                  [ 62%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_get_image_files PASSED                                                                                  [ 62%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_get_image_files_empty PASSED                                                                            [ 63%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_get_image_files_mixed_ext PASSED                                                                        [ 64%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_aggregate_summary PASSED                                                                                [ 65%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_process_single_dir_center PASSED                                                                        [ 65%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_process_single_dir_side PASSED                                                                          [ 66%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_process_single_dir_empty PASSED                                                                         [ 67%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_process_single_dir_missing_params PASSED                                                                [ 68%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_process_vertical_stitch_single_filter PASSED                                                            [ 68%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_process_vertical_stitch_empty_filters PASSED                                                            [ 69%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_process_vertical_stitch_missing_dir PASSED                                                              [ 70%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_process_vertical_stitch_missing_params PASSED                                                           [ 71%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_process_vertical_stitch_custom_suffix PASSED                                                            [ 72%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_error_handling_corrupt_image PASSED                                                                     [ 72%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_error_handling_partial_failure PASSED                                                                   [ 73%]
tests/unittests/rules/test_rule6_2.py::TestRule6_2::test_z_process_vertical_stitch_multiple_filters PASSED                                                       [ 74%]
tests/unittests/services/test_postprocessor.py::TestLoadUserConf::test_user_conf_dict_input PASSED                                                               [ 75%]
tests/unittests/services/test_postprocessor.py::TestLoadUserConf::test_user_conf_json_path_input PASSED                                                          [ 75%]
tests/unittests/services/test_postprocessor.py::TestLoadUserConf::test_user_conf_invalid_type PASSED                                                             [ 76%]
tests/unittests/services/test_postprocessor.py::TestLoadUserConf::test_user_conf_invalid_json PASSED                                                             [ 77%]
tests/unittests/services/test_postprocessor.py::TestLoadUserConf::test_user_conf_file_not_found PASSED                                                           [ 78%]
tests/unittests/services/test_postprocessor.py::TestMergeConfFromCompleteConfig::test_complete_config_merge PASSED                                               [ 79%]
tests/unittests/services/test_postprocessor.py::TestCreateErrorResponse::test_error_response_format PASSED                                                       [ 79%]
tests/unittests/services/test_postprocessor.py::TestStageFunctions::test_small_image_filter_empty PASSED                                                         [ 80%]
tests/unittests/services/test_postprocessor.py::TestStageFunctions::test_small_image_score_empty PASSED                                                          [ 81%]
tests/unittests/services/test_postprocessor.py::TestStageFunctions::test_horizontal_image_score_empty PASSED                                                     [ 82%]
tests/unittests/services/test_postprocessor.py::TestStageFunctions::test_standard_input_empty PASSED                                                             [ 82%]
tests/unittests/services/test_postprocessor.py::TestAddDecorationBorders::test_add_decoration_borders_input_dir_not_found PASSED                                 [ 83%]
tests/unittests/services/test_postprocessor.py::TestAddDecorationBorders::test_add_decoration_borders_missing_tdw PASSED                                         [ 84%]
tests/unittests/services/test_postprocessor.py::TestAddDecorationBorders::test_add_decoration_borders_success PASSED                                             [ 85%]
tests/unittests/services/test_postprocessor.py::TestPostprocessorIntegration::test_stage_failure_propagation PASSED                                              [ 86%]
tests/unittests/services/test_postprocessor.py::TestPostprocessorIntegration::test_success_response_format PASSED                                                [ 86%]
tests/unittests/services/test_postprocessor.py::TestPostprocessorIntegration::test_user_conf_dict_input PASSED                                                   [ 87%]
tests/unittests/services/test_postprocessor.py::TestPostprocessorIntegration::test_user_conf_invalid_type PASSED                                                 [ 88%]
tests/unittests/services/test_postprocessor.py::TestPostprocessorIntegration::test_user_conf_json_path_input PASSED                                              [ 89%]
tests/unittests/services/test_postprocessor.py::TestPositiveExample::test_positive_example PASSED                                                                [ 89%]
tests/unittests/services/test_preprocessor.py::TestTireImagePreprocessingPipeline::test_basic_workflow PASSED                                                    [ 90%]
tests/unittests/test_utils/test_cv_utils.py::TestAddGrayBorders::test_add_borders_with_array PASSED                                                              [ 91%]
tests/unittests/test_utils/test_cv_utils.py::TestAddGrayBorders::test_add_borders_with_file_path PASSED                                                          [ 92%]
tests/unittests/test_utils/test_cv_utils.py::TestAddGrayBorders::test_content_width_larger_than_image PASSED                                                     [ 93%]
tests/unittests/test_utils/test_cv_utils.py::TestAddGrayBorders::test_content_width_zero PASSED                                                                  [ 93%]
tests/unittests/test_utils/test_cv_utils.py::TestAddGrayBorders::test_content_width_equal_to_image PASSED                                                        [ 94%]
tests/unittests/test_utils/test_cv_utils.py::TestAddGrayBorders::test_alpha_values PASSED                                                                        [ 95%]
tests/unittests/test_utils/test_cv_utils.py::TestAddGrayBorders::test_custom_gray_color PASSED                                                                   [ 96%]
tests/unittests/test_utils/test_cv_utils.py::TestAddGrayBorders::test_default_alpha_value PASSED                                                                 [ 96%]
tests/unittests/test_utils/test_cv_utils.py::TestAddGrayBorders::test_default_gray_color PASSED                                                                  [ 97%]
tests/unittests/test_utils/test_cv_utils.py::TestAddGrayBorders::test_missing_tire_design_width PASSED                                                           [ 98%]
tests/unittests/test_utils/test_cv_utils.py::TestAddGrayBorders::test_invalid_image_path PASSED                                                                  [ 99%]
tests/unittests/test_utils/test_cv_utils.py::TestAddGrayBorders::test_real_image_processing PASSED                                                               [100%]

=================================================================== 128 passed, 1 skipped in 22.85s ====================================================================

```

## 能证明算法正确性的关键中间打印/截图
无需（本次为 Bug 修复，不涉及算法逻辑变更）