### PR TITLE
HotFix:给RuleConfig.rule_type增加默认值，避免检查报错

### DIFF
--- a/src/models/rule_models.py
+++ b/src/models/rule_models.py
@@ -122,7 +122,7 @@ class BaseRuleConfig(BaseModel):
 
     description: str = Field(description="规则描述")
     max_score: Optional[int] = Field(default=None, ge=0, description="最大可得分，None表示非打分规则")
-    rule_type: RuleTypeEnum = Field(description="规则类型枚举")
+    rule_type: Optional[RuleTypeEnum] = Field(default=None, description="规则类型枚举")
     @property
     def name(self) -> str:
         """规则名称，从类名自动提取（如Rule8Config → rule8）"""


### PR DESCRIPTION
以下是按照模版整理的 PR 内容：

---

## 1. 提交目标
- 将 `dev2_fixbug` 分支合并到 `dev2`

## 2. 提交类型
- fix

## 3. Commit 号、pytest 和 coverage 结果

### Commit 号
- b3da218 HotFix:给RuleConfig.rule_type增加默认值，避免检查报错

### pytest
```bash
pytest -v tests    
```

结果：
-519 passed, 2 skipped, 47 subtests passed in 2.06s

### coverage
```bash

```

结果：
不需要

## 4. 新增测试用例逻辑描述
- 无新增测试，原因：hotfix，仅修改字段默认值，不涉及逻辑变更

## 5. 需求 / 设计来源
- 需求来源：解决 RuleConfig 缺少 rule_type 默认值导致检查报错的问题
- 设计文档：不适用
- 相关 issue / task：无

## 6. 改动范围与摘要

### 实际修改文件
- `src/models/rule_models.py`

### 明确未修改内容
- 除上述文件外，其他文件均未修改
- `version.json`

### 变更摘要
- `BaseRuleConfig.rule_type` 字段从必填改为可选（`Optional[RuleTypeEnum]`），并设置默认值 `default=None`，解决实例化时缺少该字段导致的校验报错

## 7. 补充说明
- 无

---

### 差异概要

| 项目 | 内容 |
|------|------|
| 分支 | `dev2_fixbug` → `dev2` |
| 提交数 | 1 |
| 修改文件 | 1 个 (`src/models/rule_models.py`) |
| 变更行数 | +1 / -1 |
| 具体改动 | `rule_type: RuleTypeEnum` 改为 `rule_type: Optional[RuleTypeEnum] = Field(default=None, ...)` |

核心改动在 `src/models/rule_models.py:125`，将 `BaseRuleConfig` 的 `rule_type` 从必填字段改为可选并赋予 `None` 默认值，避免 Pydantic 校验时报错。