### PR TITLE
fix(node): 同步拼接方案生成写回大图

### DIFF
--- a/src/nodes/stitch_scheme_generator.py
+++ b/src/nodes/stitch_scheme_generator.py
@@ -16,6 +16,7 @@ from src.models.enums import RibOperation, SourceTypeEnum, StitchingSchemeName
 from src.models.image_models import (
     ImageLineage,
     SmallImage,
+    BigImage
 )
 from src.models.template_registry import get_stitching_templates
 from src.models.rule_models import (
@@ -751,10 +752,11 @@ def _log_lineage_detail(lineage: ImageLineage) -> None:
 
 
 def generate_stitch_scheme(
+    big_image: BigImage,
     small_images: Sequence[SmallImage],
     rules_config: Sequence[BaseRuleConfig],
     scheme_rank: int,
-) -> ImageLineage:
+) -> BigImage:
     """根据小图、规则配置和排名生成指定的拼接 lineage。"""
 
     if scheme_rank < 1:
@@ -894,4 +896,6 @@ def generate_stitch_scheme(
     )
     _log_lineage_detail(lineage)
 
-    return lineage
+    big_image.lineage = lineage
+
+    return big_image

--- a/tests/integrations/test_stitch_scheme_generator.py
+++ b/tests/integrations/test_stitch_scheme_generator.py
@@ -13,6 +13,7 @@ from src.models.enums import (
     RibOperation,
 )
 from src.models.image_models import (
+    BigImage,
     ImageLineage,
     ImageBiz,
     ImageEvaluation,
@@ -80,6 +81,26 @@ def make_small_image(region: RegionEnum, payload: str, score: int) -> SmallImage
         ),
     )
 
+
+def make_big_image() -> BigImage:
+    return BigImage(
+        image_base64="data:image/png;base64,big",
+        meta=ImageMeta(
+            width=10,
+            height=10,
+            channels=3,
+            mode=ImageModeEnum.RGB,
+            format=ImageFormatEnum.PNG,
+            size=10,
+        ),
+        biz=ImageBiz(
+            level=LevelEnum.BIG,
+            region=RegionEnum.CENTER,
+            source_type=SourceTypeEnum.ORIGINAL,
+        ),
+    )
+
+
 def test_generate_stitch_scheme(small_images=None, rules_config=None):
     if not small_images:
         small_images = [
@@ -121,7 +142,10 @@ def test_generate_stitch_scheme(small_images=None, rules_config=None):
         ]
 
     
-    generate_stitch_scheme(small_images, rules_config, 1)
+    result = generate_stitch_scheme(make_big_image(), small_images, rules_config, 1)
+
+    assert isinstance(result, BigImage)
+    assert isinstance(result.lineage, ImageLineage)
 
 
 def test_sort_and_lineage():

--- a/tests/unittests/nodes/test_stitch_scheme_generator.py
+++ b/tests/unittests/nodes/test_stitch_scheme_generator.py
@@ -13,6 +13,7 @@ from src.models.enums import (
     RibOperation,
 )
 from src.models.image_models import (
+    BigImage,
     ImageLineage,
     ImageBiz,
     ImageEvaluation,
@@ -21,6 +22,7 @@ from src.models.image_models import (
     SmallImage,
 )
 from src.models.rule_models import (
+    BaseRuleConfig,
     DecorationItem,
     GrooveSizeItem,
     RibSizeItem,
@@ -87,6 +89,37 @@ def make_small_image(region: RegionEnum, payload: str, score: int) -> SmallImage
             current_score=score,
         ),
     )
+
+
+def make_big_image() -> BigImage:
+    return BigImage(
+        image_base64="data:image/png;base64,big",
+        meta=ImageMeta(
+            width=10,
+            height=10,
+            channels=3,
+            mode=ImageModeEnum.RGB,
+            format=ImageFormatEnum.PNG,
+            size=10,
+        ),
+        biz=ImageBiz(
+            level=LevelEnum.BIG,
+            region=RegionEnum.CENTER,
+            source_type=SourceTypeEnum.ORIGINAL,
+        ),
+    )
+
+
+def generate_lineage_for_test(
+    small_images: list[SmallImage],
+    rules_config: list[BaseRuleConfig],
+    scheme_rank: int,
+) -> ImageLineage:
+    result = generate_stitch_scheme(make_big_image(), small_images, rules_config, scheme_rank)
+
+    assert isinstance(result, BigImage)
+    assert isinstance(result.lineage, ImageLineage)
+    return result.lineage
 
 
 class Rule3Template(StitchingTemplate):
@@ -437,9 +470,11 @@ def test_generate_stitch_scheme_returns_requested_ranked_scheme():
         ),
     ]
 
-    result = generate_stitch_scheme(small_images, rules_config, 1)
+    result_big_image = generate_stitch_scheme(make_big_image(), small_images, rules_config, 1)
 
-    assert isinstance(result, ImageLineage)
+    assert isinstance(result_big_image, BigImage)
+    assert isinstance(result_big_image.lineage, ImageLineage)
+    result = result_big_image.lineage
     expected_scheme_name = StitchingSchemeName.SYMMETRY_0
     expected_rib_count = 5
     expected_rib_sizes = [
@@ -521,7 +556,7 @@ def test_generate_stitch_scheme_uses_best_subset_when_input_images_are_more_than
         ),
     ]
 
-    result = generate_stitch_scheme(small_images, rules_config, 1)
+    result = generate_lineage_for_test(small_images, rules_config, 1)
 
     assert {rib.before_image for rib in result.stitching_scheme.ribs_scheme_implementation} <= {
         "data:image/png;base64,side-a",
@@ -570,7 +605,7 @@ def test_generate_stitch_scheme_rejects_rank_out_of_range():
     out_of_range_scheme_rank = 37
 
     with pytest.raises(InputDataError, match="scheme_rank"):
-        generate_stitch_scheme(small_images, rules_config, out_of_range_scheme_rank)
+        generate_stitch_scheme(make_big_image(), small_images, rules_config, out_of_range_scheme_rank)
 
 
 def test_generate_stitch_scheme_supports_inherited_ribs():
@@ -606,7 +641,7 @@ def test_generate_stitch_scheme_supports_inherited_ribs():
         ),
     ]
 
-    result = generate_stitch_scheme(small_images, rules_config, 1)
+    result = generate_lineage_for_test(small_images, rules_config, 1)
 
     expected_rib_names = [
         "rib1",
@@ -830,7 +865,7 @@ def test_generate_stitch_scheme_rejects_missing_rib_size_config():
     ]
 
     with pytest.raises(InputDataError, match="rib_sizes"):
-        generate_stitch_scheme(small_images, rules_config, 1)
+        generate_stitch_scheme(make_big_image(), small_images, rules_config, 1)
 
 
 def test_generate_stitch_scheme_logs_key_execution_steps(caplog):
@@ -869,7 +904,7 @@ def test_generate_stitch_scheme_logs_key_execution_steps(caplog):
     ]
 
     with caplog.at_level("DEBUG", logger="拼接方案"):
-        generate_stitch_scheme(small_images, rules_config, 1)
+        generate_stitch_scheme(make_big_image(), small_images, rules_config, 1)
 
     messages = [record.message for record in caplog.records]
     expected_formula_log = "公式=A[2,2]*A[3,3] + A[2,2]*A[3,3] + A[2,2]*A[3,3] = 12 + 12 + 12 = 36"


### PR DESCRIPTION
﻿## 1. 提交目标
- 修复 Node2 拼接方案生成接口改为写回 BigImage 后，lineage 生成结果和测试用例未同步的问题。

## 2. 提交类型
- fix

## 3. Commit 号、pytest 和 coverage 结果

### Commit 号
- 8cad419b82c4572dc1dd2ef7a8b40f2d01622562 fix(node): 同步拼接方案生成写回大图

### pytest
```bash
.\.venv\Scripts\python.exe -m pytest tests -q
```
结果：
- 611 passed, 2 skipped, 53 subtests passed in 3.98s

### coverage
```bash
.\.venv\Scripts\python.exe -m pytest --cov=src.nodes.stitch_scheme_generator --cov-report=term-missing tests/unittests/nodes/test_stitch_scheme_generator.py tests/integrations/test_stitch_scheme_generator.py
```
结果：
- 26 passed
- src\nodes\stitch_scheme_generator.py 覆盖率 85%

## 4. 新增测试用例逻辑描述
- 更新 Node2 单元测试和集成测试，使其按新接口传入 BigImage。
- 验证 generate_stitch_scheme 返回 BigImage，并将生成的 ImageLineage 写入 result.lineage。
- 保留原有拼接方案排序、候选筛选、异常分支和日志断言。

## 5. 需求 / 设计来源
- 需求来源：本次修复任务，要求同步 stitch_scheme_generator.py 的 BigImage 写回行为及对应测试。
- 设计文档：docs/ai_context_entrypoint.md、docs/project_coding_standards.md、docs/project_coding_standards_agent.md
- 相关 issue / task：无

## 6. 改动范围与摘要

### 实际修改文件
- src/nodes/stitch_scheme_generator.py
- tests/unittests/nodes/test_stitch_scheme_generator.py
- tests/integrations/test_stitch_scheme_generator.py

### 明确未修改内容
- 未修改规则执行器、模型定义、pipeline 其它节点和 API 层。
- `version.json`

### 变更摘要
- generate_stitch_scheme 接收 BigImage，并在生成 lineage 后写回 big_image.lineage。
- 单元测试新增 BigImage 构造辅助函数，并从 result.lineage 继续验证原有 lineage 内容。
- 集成测试同步新接口调用并校验返回 BigImage 的 lineage 已生成。
